### PR TITLE
fix: Correct JUnit XML path for Xray uploader

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,8 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    pytest --junitxml=results.xml
+    mkdir -p reports
+    pytest --junitxml=reports/results.xml
   displayName: 'Run Pytest and Upload to Xray Cloud'
   env:
     # Expose Azure DevOps secret variables as environment variables for the script


### PR DESCRIPTION
This commit modifies `azure-pipelines.yml` to ensure the JUnit XML report is generated in the `reports/` subdirectory.

The `pytest-xray-reporter` plugin, when using `curl` for uploading, was observed to be looking for the results file at `reports/results.xml`. The previous configuration generated `results.xml` in the root directory, causing a "Failed to open" error during the upload attempt.

The pipeline script now includes `mkdir -p reports` and uses `pytest --junitxml=reports/results.xml` to align the output path with the plugin's expectation.